### PR TITLE
Feature/persona changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "buffer": "^6.0.3",
         "file-saver": "^2.0.5",
         "immer": "^9.0.12",
+        "jspdf": "^2.5.1",
         "laravel-echo": "^1.13.1",
         "node-sass": "^9.0.0",
         "popper.js": "^1.16.1",
@@ -4513,6 +4514,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
       "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.2.tgz",
+      "integrity": "sha512-sM4HyDVlDFl4goOXPF+g9nNHJFZQGot+HgySjM4cRjqXzjdatcEvYrtG4Ia8XumR9T6k8G2tW9B7hnUj51Uf0A==",
+      "optional": true
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
@@ -5680,7 +5687,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -6045,6 +6051,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6340,6 +6355,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -6588,6 +6614,31 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -7365,6 +7416,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -8337,6 +8397,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+      "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==",
+      "optional": true
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -11396,6 +11462,19 @@
         "webpack": "^5.20.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -14234,6 +14313,28 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
@@ -19017,6 +19118,15 @@
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -20139,6 +20249,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.6.0.tgz",
+      "integrity": "sha512-8S1aIA+UoF6erJYnglGPug6MaHYGo1Ot7h5fuXx4fUPvcvQfcdw2o/ppCse63+eZf8PPidSu4v1JnmEVtEDnpg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -20704,6 +20823,15 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -21060,6 +21188,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -21913,6 +22050,15 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "buffer": "^6.0.3",
     "file-saver": "^2.0.5",
     "immer": "^9.0.12",
+    "jspdf": "^2.5.1",
     "laravel-echo": "^1.13.1",
     "node-sass": "^9.0.0",
     "popper.js": "^1.16.1",

--- a/src/components/tools/persona-analysis/PersonaAnalysis.tsx
+++ b/src/components/tools/persona-analysis/PersonaAnalysis.tsx
@@ -11,9 +11,7 @@ import {PersonaPersonalityValues} from "./steps/PersonaPersonality/PersonaPerson
 import {PersonaPersonality} from "./steps/PersonaPersonality/PersonaPersonality";
 import {PersonaSummaryValues} from "./steps/PersonaSummary/PersonaSummaryComponent";
 import {PersonaSummary} from "./steps/PersonaSummary/PersonaSummary";
-import {PDFExporter} from "../../../general-components/Export/PDFExporter";
-import {SingleMessageProps} from "../../../general-components/Messages/Messages";
-
+import {PersonaPDFExporter} from "./export/PersonaPDFExporter";
 
 interface PersonaAnalysisValues {
     "persona-info"?: PersonaInfoValues,
@@ -27,17 +25,7 @@ class PersonaAnalysis extends SteppableTool<PersonaAnalysisValues> {
         super(props, context, "Persona Analyse", faUserCircle, 6);
 
         this.addExporter(new JSONExporter());
-        this.addExporter(new PDFExporter<PersonaAnalysisValues>("#persona-summary", (save) => {
-            let errors: SingleMessageProps[] = [];
-            if (save.data["persona-summary"] === undefined) {
-                errors.push({
-                    content: "Bitte stellen Sie Ihr Persona erst fertig!",
-                    type: "DANGER"
-                });
-            }
-            return errors;
-        }));
-
+        this.addExporter(new PersonaPDFExporter());
         this.setImporter(new PersonaJSONImporter());
 
         this.addStep(new PersonaInfo());

--- a/src/components/tools/persona-analysis/PersonaAnalysis.tsx
+++ b/src/components/tools/persona-analysis/PersonaAnalysis.tsx
@@ -11,6 +11,8 @@ import {PersonaPersonalityValues} from "./steps/PersonaPersonality/PersonaPerson
 import {PersonaPersonality} from "./steps/PersonaPersonality/PersonaPersonality";
 import {PersonaSummaryValues} from "./steps/PersonaSummary/PersonaSummaryComponent";
 import {PersonaSummary} from "./steps/PersonaSummary/PersonaSummary";
+import {PDFExporter} from "../../../general-components/Export/PDFExporter";
+import {SingleMessageProps} from "../../../general-components/Messages/Messages";
 
 
 interface PersonaAnalysisValues {
@@ -25,6 +27,17 @@ class PersonaAnalysis extends SteppableTool<PersonaAnalysisValues> {
         super(props, context, "Persona Analyse", faUserCircle, 6);
 
         this.addExporter(new JSONExporter());
+        this.addExporter(new PDFExporter<PersonaAnalysisValues>("#persona-summary", (save) => {
+            let errors: SingleMessageProps[] = [];
+            if (save.data["persona-summary"] === undefined) {
+                errors.push({
+                    content: "Bitte stellen Sie Ihr Persona erst fertig!",
+                    type: "DANGER"
+                });
+            }
+            return errors;
+        }));
+
         this.setImporter(new PersonaJSONImporter());
 
         this.addStep(new PersonaInfo());

--- a/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
+++ b/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
@@ -37,7 +37,7 @@ class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {
         this.addNameValuePairs(doc, "Erstellt von:", [save.owner.username], this.getWidth(doc, sizes.width), undefined, 3);
 
         // Persona info
-        this.addNameValuePairs(doc, "Vorname:", [infos.firstname!], avatarSizes.width + 7, undefined, padding)
+        this.addNameValuePairs(doc, "Name:", [infos.firstname!], avatarSizes.width + 7, undefined, padding)
         this.addNameValuePairs(doc, "Alter:", [`${infos.age} ${infos.age! === 1 ? "Jahr" : "Jahre"} alt`], avatarSizes.width + 7, undefined, padding);
 
         let income = new Intl.NumberFormat(
@@ -74,12 +74,12 @@ class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {
             let item = items[i];
 
             // Leftitem
-            sizes = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), 0, this.height, padding);
+            sizes = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), 0, this.height, padding, true);
 
             if (i + 1 < items.length) {
                 item = items[i + 1]
                 // Rightitem
-                let sizesB = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), this.getWidth(doc, sizes.width), this.height, padding);
+                let sizesB = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), this.getWidth(doc, sizes.width), this.height, padding,  true);
 
                 if (sizes.height > sizesB.height) {
                     this.height += sizes.height;
@@ -101,7 +101,7 @@ class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {
         return errors;
     }
 
-    private addNameValuePairs(doc: jsPDF, name: string, values: string[], width: number, useHeight?: number, heightPadding?: number) {
+    private addNameValuePairs(doc: jsPDF, name: string, values: string[], width: number, useHeight?: number, heightPadding?: number, useMinus?: boolean) {
         if (values.length === 0) {
             values.push("Keine angaben");
         }
@@ -133,6 +133,10 @@ class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {
 
         doc.setFontSize(11);
         values.forEach((v) => {
+            if (useMinus) {
+                v = `- ${v}`;
+            }
+
             if (useHeight) {
                 let add = doc.getTextDimensions(v, {fontSize: 11}).h;
                 height += add;

--- a/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
+++ b/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
@@ -1,0 +1,175 @@
+import {PDFExporter} from "../../../../general-components/Export/PDF/PDFExporter";
+import {PersonaAnalysisValues} from "../PersonaAnalysis";
+import {SaveResource} from "../../../../general-components/Datastructures";
+import {SingleMessageProps} from "../../../../general-components/Messages/Messages";
+import jsPDF from "jspdf";
+import {Buffer} from 'buffer';
+import {ResourcesType} from "../../../../general-components/Tool/ToolSavePage/ToolSavePage";
+import {getFamilyStatus} from "../steps/PersonaInfo/PersonaInfoComponent";
+import {PersonaPersonalityComponent} from "../steps/PersonaPersonality/PersonaPersonalityComponent";
+import {PersonaSummaryItem} from "../steps/PersonaSummary/PersonaSummaryComponent";
+import {info} from "autoprefixer";
+
+
+class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {
+
+    buildPDF = async (doc: jsPDF, save: SaveResource<PersonaAnalysisValues>, resources: ResourcesType): Promise<void> => {
+        let infos = save.data["persona-info"]!;
+        let personality = save.data["persona-personality"]!;
+
+        this.setTitle(`Persona: ${infos!.firstname}`);
+
+        let avatar = resources.get("avatar")!;
+        let avatarSizes = await this.getImageSizes(avatar.file, 60, 80);
+
+        doc.addImage({
+            imageData: new Buffer(await avatar.file.arrayBuffer()).toString("base64"),
+            width: avatarSizes.width,
+            height: avatarSizes.height,
+            format: "JPEG",
+            x: this.getWidth(doc, 0),
+            y: this.CalculateImageHeight(doc)
+        });
+
+        let padding = 4.5;
+
+        // Main info
+        let sizes = this.addNameValuePairs(doc, "Persona erstellt am:", [`${new Date(save.created_at).toLocaleString("de-DE")} Uhr`], avatarSizes.width + 7, this.height, padding);
+        this.addNameValuePairs(doc, "Erstellt von:", [save.owner.username], this.getWidth(doc, sizes.width), undefined, 3);
+
+        // Persona info
+        this.addNameValuePairs(doc, "Vorname:", [infos.firstname!], avatarSizes.width + 7, undefined, padding)
+        this.addNameValuePairs(doc, "Alter:", [`${infos.age} ${infos.age! === 1 ? "Jahr" : "Jahre"} alt`], avatarSizes.width + 7, undefined, padding);
+
+        let income = new Intl.NumberFormat(
+            "de-DE",
+            {
+                style: "currency",
+                currency: "EUR"
+            }
+        ).format(infos.income ?? 0);
+
+        this.addNameValuePairs(doc, "Einkommen:", [infos.income === null ? "Keins angegeben" : `Monatlicher Nettoverdienst von ${income}`], avatarSizes.width + 7, undefined, padding);
+        this.addNameValuePairs(doc, "Familienstatus:", [getFamilyStatus(infos.familystatus)!], avatarSizes.width + 7);
+
+        // Personalität
+        let items: PersonaSummaryItem[] = [
+            {
+                name: "Familie & Freunde",
+                fields: infos.family,
+                icon: undefined
+            },
+            ...Object.values(personality.fields).map<PersonaSummaryItem>((data, index) => {
+                return {
+                    name: PersonaPersonalityComponent.names[index],
+                    fields: data,
+                    icon: PersonaPersonalityComponent.icons[index]
+                };
+            }),
+            ...personality.individual
+        ];
+
+
+        this.height = 96;
+        for (let i = 0; i < items.length; i += 2) {
+            let item = items[i];
+
+            // Leftitem
+            sizes = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), 0, this.height, padding);
+
+            if (i + 1 < items.length) {
+                item = items[i + 1]
+                // Rightitem
+                let sizesB = this.addNameValuePairs(doc, item.name, item.fields.map(i => i.name), this.getWidth(doc, sizes.width), this.height, padding);
+
+                if (sizes.height > sizesB.height) {
+                    this.height += sizes.height;
+                } else {
+                    this.height += sizesB.height;
+                }
+            }
+        }
+    }
+
+    public validateExport(save: SaveResource<PersonaAnalysisValues>): SingleMessageProps[] {
+        let errors: SingleMessageProps[] = [];
+        if (save.data["persona-summary"] === undefined) {
+            errors.push({
+                content: "Bitte stellen Sie Ihr Persona erst fertig!",
+                type: "DANGER"
+            });
+        }
+        return errors;
+    }
+
+    private addNameValuePairs(doc: jsPDF, name: string, values: string[], width: number, useHeight?: number, heightPadding?: number) {
+        if (values.length === 0) {
+            values.push("Keine angaben");
+        }
+
+        let newWidth: number;
+        let newHeight = 0;
+        let height = 0;
+        if (useHeight) {
+            newHeight = doc.getTextDimensions(name, {fontSize: 13}).h
+            height = useHeight + newHeight;
+        } else {
+            height = this.CalculateTextHeight(doc, name, 13);
+        }
+
+        // Name
+        newWidth = this.getWidth(doc, width);
+        doc.setFontSize(12);
+        doc.setFont("Helvetica", "bold");
+        doc.text(
+            name,
+            newWidth,
+            height
+        );
+        doc.setFont("Helvetica", "normal");
+
+        // Value
+        let hightestWidth = doc.getTextDimensions(name, {fontSize: 12}).w;
+        let lastLength = name.length;
+
+        doc.setFontSize(11);
+        values.forEach((v) => {
+            if (useHeight) {
+                let add = doc.getTextDimensions(v, {fontSize: 11}).h;
+                height += add;
+                newHeight += add
+            } else {
+                height = this.CalculateTextHeight(doc, v, 11);
+            }
+
+            if (v.length > lastLength) {
+                hightestWidth = doc.getTextDimensions(v, {fontSize: 11}).w;
+                lastLength = v.length;
+            }
+
+            doc.text(
+                v,
+                this.getWidth(doc, width),
+                height
+            );
+        });
+        newWidth += hightestWidth;
+
+        if (!useHeight && heightPadding) {
+            this.addHeightPadding(heightPadding);
+            height += heightPadding;
+        }
+        if (heightPadding) {
+            newHeight += heightPadding;
+        }
+
+        return {
+            width: newWidth,
+            height: newHeight
+        };
+    }
+}
+
+export {
+    PersonaPDFExporter
+}

--- a/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
+++ b/src/components/tools/persona-analysis/export/PersonaPDFExporter.tsx
@@ -8,7 +8,6 @@ import {ResourcesType} from "../../../../general-components/Tool/ToolSavePage/To
 import {getFamilyStatus} from "../steps/PersonaInfo/PersonaInfoComponent";
 import {PersonaPersonalityComponent} from "../steps/PersonaPersonality/PersonaPersonalityComponent";
 import {PersonaSummaryItem} from "../steps/PersonaSummary/PersonaSummaryComponent";
-import {info} from "autoprefixer";
 
 
 class PersonaPDFExporter extends PDFExporter<PersonaAnalysisValues> {

--- a/src/components/tools/persona-analysis/matrix/PersonaAnalysisInfoShower.tsx
+++ b/src/components/tools/persona-analysis/matrix/PersonaAnalysisInfoShower.tsx
@@ -12,7 +12,7 @@ class PersonaAnalysisInfoShower extends ExtraWindowComponent<PersonaAnalysisValu
         if (data) {
             return (
                 <div className={"persona-info-shower"}>
-                    <div className={"name"}>{data.firstname} {data.lastname}</div>
+                    <div className={"name"}>{data.firstname}</div>
                     <div className={"image-container"}>
                         <Image src={this.props.resourceManager.getBlobURL("avatar") ?? undefined} thumbnail
                                className={"image"} alt={"Avatar vom Persona"}/>

--- a/src/components/tools/persona-analysis/matrix/PersonaAnalysisInfoShower.tsx
+++ b/src/components/tools/persona-analysis/matrix/PersonaAnalysisInfoShower.tsx
@@ -2,7 +2,6 @@ import {ExtraWindowComponent} from "../../../../general-components/Tool/ExtraWin
 import {PersonaAnalysisValues} from "../PersonaAnalysis";
 import "./persona-info-shower.scss";
 import {Image} from "react-bootstrap";
-import {getFamilyStatus} from "../steps/PersonaInfo/PersonaInfoComponent";
 
 class PersonaAnalysisInfoShower extends ExtraWindowComponent<PersonaAnalysisValues, {}> {
 
@@ -20,12 +19,6 @@ class PersonaAnalysisInfoShower extends ExtraWindowComponent<PersonaAnalysisValu
                     <div className={"info"}>
                         <div className={"age"}>
                             {data.age} {((data.age ?? -1) === 1) ? "Jahr" : "Jahre"} alt
-                            {(data.familystatus !== 0) && (
-                                <>
-                                    <br/>
-                                    Familienstand: {getFamilyStatus(data.familystatus)}
-                                </>
-                            )}
                         </div>
                     </div>
                 </div>

--- a/src/components/tools/persona-analysis/persona-analysis.scss
+++ b/src/components/tools/persona-analysis/persona-analysis.scss
@@ -80,17 +80,27 @@
     }
   }
 
-  .info-element {
-    margin-bottom: 1rem;
+  // flex
+  .items {
+    column-gap: 1.5rem;
+    columns: 2;
+    column-fill: balance;
 
-    .name {
-      font-weight: 600;
-      font-size: 12.5pt;
-      margin-bottom: 0.35rem;
+    .avatar-item {
+      position: static;
     }
 
-    .list-group-item {
-      padding: 0.35rem 0.5rem;
+    .item {
+      display: inline-block;
+      width: 100%;
+      direction: ltr;
+      text-align: left;
+    }
+  }
+
+  @media screen and (max-width: 767px) {
+    .items {
+      column-count: 1;
     }
   }
 }

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfo.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfo.ts
@@ -40,7 +40,6 @@ export class PersonaInfo implements StepDefinition<PersonaAnalysisValues>, StepD
     fillFromPreviousValues = (data: PersonaAnalysisValues): PersonaAnalysisValues => {
         data["persona-info"] = {
             "firstname": null,
-            "lastname": null,
             "age": null,
             "income": null,
             "family": [],
@@ -97,21 +96,6 @@ export class PersonaInfo implements StepDefinition<PersonaAnalysisValues>, StepD
             errors.push({
                 id: "firstname.toolong",
                 message: "Der Vorname darf nur maximal " + PersonaInfo.FIRST_NAME_MAX_LENGTH + " Zeichen besitzen!",
-                level: "error"
-            });
-        }
-
-        // Nachname
-        if (d?.lastname == null || d.lastname.length <= 0) {
-            errors.push({
-                id: "lastname.empty",
-                message: "Bitte geben Sie einen Nachnamen an!",
-                level: "error"
-            });
-        } else if (d.lastname.length > PersonaInfo.LAST_NAME_MAX_LENGTH) {
-            errors.push({
-                id: "lastname.toolong",
-                message: "Der Nachname darf nur maximal " + PersonaInfo.LAST_NAME_MAX_LENGTH + " Zeichen besitzen!",
                 level: "error"
             });
         }

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfo.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfo.ts
@@ -7,21 +7,15 @@ import {UIError} from "../../../../../general-components/Error/UIErrors/UIError"
 import React from "react";
 import {PersonaInfoComponent} from "./PersonaInfoComponent";
 import {PersonaAnalysisValues} from "../../PersonaAnalysis";
-import {isCardComponentTooLong} from "../../../../../general-components/CardComponent/CardComponent";
 import {ResourcesType} from "../../../../../general-components/Tool/ToolSavePage/ToolSavePage";
 import {validateFile} from "../../../../../general-components/Tool/Resources";
 
 
 export class PersonaInfo implements StepDefinition<PersonaAnalysisValues>, StepDataHandler<PersonaAnalysisValues> {
-
     static FIRST_NAME_MAX_LENGTH = 100;
-    static LAST_NAME_MAX_LENGTH = PersonaInfo.FIRST_NAME_MAX_LENGTH;
 
     static AGE_MIN = 0;
     static AGE_MAX = 150;
-
-    static INCOME_MIN = 0;
-    static INCOME_MAX = 10000000;
 
     form: React.FunctionComponent<StepProp<PersonaAnalysisValues>> | React.ComponentClass<StepProp<PersonaAnalysisValues>>;
     id: string;
@@ -40,10 +34,7 @@ export class PersonaInfo implements StepDefinition<PersonaAnalysisValues>, StepD
     fillFromPreviousValues = (data: PersonaAnalysisValues): PersonaAnalysisValues => {
         data["persona-info"] = {
             "firstname": null,
-            "age": null,
-            "income": null,
-            "family": [],
-            "familystatus": 0
+            "age": null
         };
         return data;
     }
@@ -105,23 +96,6 @@ export class PersonaInfo implements StepDefinition<PersonaAnalysisValues>, StepD
             errors.push({
                 id: "age.invalid",
                 message: `Bitte geben Sie eine Zahl zwischen ${PersonaInfo.AGE_MIN} und ${PersonaInfo.AGE_MAX} an!`,
-                level: "error"
-            });
-        }
-
-        // Einkommen
-        if (d?.income !== null && d?.income !== undefined && (d?.income === -1 || (d?.income < PersonaInfo.INCOME_MIN || d?.income > PersonaInfo.INCOME_MAX))) {
-            errors.push({
-                id: "income.invalid",
-                message: `Bitte geben Sie ein Einkommen zwischen ${PersonaInfo.INCOME_MIN} € und ${PersonaInfo.INCOME_MAX} € an!`,
-                level: "error"
-            });
-        }
-
-        if (isCardComponentTooLong(d?.family)) {
-            errors.push({
-                id: "family.length",
-                message: "Der Text in einigen Feldern ist zu lang!",
                 level: "error"
             });
         }

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent-ti.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent-ti.ts
@@ -6,7 +6,6 @@ import * as t from "ts-interface-checker";
 
 export const PersonaInfoValues = t.iface([], {
     "firstname": t.union("string", "null"),
-    "lastname": t.union("string", "null"),
     "age": t.union("number", "null"),
     "income": t.union("number", "null"),
     "family": "CardComponentFields",

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent-ti.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent-ti.ts
@@ -6,10 +6,7 @@ import * as t from "ts-interface-checker";
 
 export const PersonaInfoValues = t.iface([], {
     "firstname": t.union("string", "null"),
-    "age": t.union("number", "null"),
-    "income": t.union("number", "null"),
-    "family": "CardComponentFields",
-    "familystatus": "number",
+    "age": t.union("number", "null")
 });
 
 const PersonaInfo_ts: t.ITypeSuite = {

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
@@ -14,7 +14,6 @@ import {NumberCounter} from "../../../../../general-components/Counter/NumberCou
 
 export interface PersonaInfoValues {
     "firstname": string | null,
-    "lastname": string | null,
     "age": number | null,
     "income": number | null,
     "family": CardComponentFields,
@@ -77,12 +76,12 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
                     </Col>
                     <Col sm={6}>
                         <Form.Group className="mb-3">
-                            <Form.Label>Nachname</Form.Label>
-                            <Form.Control disabled={this.props.disabled} required onChange={this.lastNameChanged}
-                                          type={"text"}
-                                          value={data?.lastname ?? ""} placeholder={"Mustermann"}/>
-                            <UIErrorBanner id={"lastname.empty"}/>
-                            <UIErrorBanner id={"lastname.toolong"}/>
+                            <Form.Label>Alter</Form.Label>
+                            <Form.Control disabled={this.props.disabled} onChange={this.ageChanged} type={"number"}
+                                          value={data?.age === -1 ? undefined : data?.age ?? ""}
+                                          min={PersonaInfo.AGE_MIN} max={PersonaInfo.AGE_MAX}
+                                          placeholder={"25"}/>
+                            <UIErrorBanner id={"age.invalid"}/>
                         </Form.Group>
                     </Col>
                 </Row>
@@ -90,12 +89,15 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
                 <Row>
                     <Col sm={6}>
                         <Form.Group className="mb-3">
-                            <Form.Label>Alter</Form.Label>
-                            <Form.Control disabled={this.props.disabled} onChange={this.ageChanged} type={"number"}
-                                          value={data?.age === -1 ? undefined : data?.age ?? ""}
-                                          min={PersonaInfo.AGE_MIN} max={PersonaInfo.AGE_MAX}
-                                          placeholder={"25"}/>
-                            <UIErrorBanner id={"age.invalid"}/>
+                            <Form.Label>Avatar/Personenfoto</Form.Label>
+                            <Form.Control disabled={this.props.disabled} type="file" onChange={this.avatarChanged}/>
+                            <Form.Text>Gültige
+                                Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text> <br/>
+                            <Form.Text>Maximalgröße: {PersonaInfoComponent.MAXFILESIZE / 1000} MB</Form.Text>
+
+                            <UIErrorBanner id={"avatar.empty"}/>
+                            <UIErrorBanner id={"avatar.size"}/>
+                            <UIErrorBanner id={"avatar.type"}/>
                         </Form.Group>
                     </Col>
                     <Col sm={6}>
@@ -107,18 +109,6 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
                         </Form.Group>
                     </Col>
                 </Row>
-
-                <Form.Group className="mb-3">
-                    <Form.Label>Avatar/Personenfoto</Form.Label>
-                    <Form.Control disabled={this.props.disabled} type="file" onChange={this.avatarChanged}/>
-                    <Form.Text>Gültige
-                        Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text> <br/>
-                    <Form.Text>Maximalgröße: {PersonaInfoComponent.MAXFILESIZE / 1000} MB</Form.Text>
-
-                    <UIErrorBanner id={"avatar.empty"}/>
-                    <UIErrorBanner id={"avatar.size"}/>
-                    <UIErrorBanner id={"avatar.type"}/>
-                </Form.Group>
 
                 <Row>
                     <Col sm={6}>
@@ -173,13 +163,6 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
         this.props.saveController.onChanged(save => {
             let data = save.data["persona-info"];
             if (data !== undefined) data.firstname = e.target.value;
-        });
-    }
-
-    lastNameChanged = (e: ChangeEvent<HTMLInputElement>) => {
-        this.props.saveController.onChanged(save => {
-            let data = save.data["persona-info"];
-            if (data !== undefined) data.lastname = e.target.value;
         });
     }
 

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
@@ -92,7 +92,8 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
                             <Form.Label>Avatar/Personenfoto</Form.Label>
                             <Form.Control disabled={this.props.disabled} type="file" onChange={this.avatarChanged}/>
                             <Form.Text>Gültige
-                                Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text> <br/>
+                                Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text>
+                            <br/>
                             <Form.Text>Maximalgröße: {PersonaInfoComponent.MAXFILESIZE / 1000} MB</Form.Text>
 
                             <UIErrorBanner id={"avatar.empty"}/>

--- a/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaInfo/PersonaInfoComponent.tsx
@@ -8,39 +8,15 @@ import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UI
 import {Col, Form, Image, Row} from "react-bootstrap";
 import {ChangeEvent} from "react";
 import {PersonaInfo} from "./PersonaInfo";
-import {CardComponent, CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
-import {NumberCounter} from "../../../../../general-components/Counter/NumberCounter";
-
 
 export interface PersonaInfoValues {
     "firstname": string | null,
-    "age": number | null,
-    "income": number | null,
-    "family": CardComponentFields,
-    "familystatus": number
-}
-
-export const getFamilyStatus = (i: number): string | undefined => {
-    switch (i) {
-        case 1:
-            return "Ledig";
-        case 2:
-            return "Verheiratet";
-        case 3:
-            return "Verwitwet";
-        case 4:
-            return "Geschieden";
-        default:
-            return "Nicht angegeben";
-    }
+    "age": number | null
 }
 
 export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
     static FILETYPES = ["png", "jpg", "jpeg"];
     static MAXFILESIZE = 2000;
-
-    static MAXFAMILY = 4;
-    static MINFAMILY = 0;
 
     public constructor(props: StepProp<PersonaAnalysisValues>, context: any) {
         super(props, context);
@@ -86,76 +62,25 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
                     </Col>
                 </Row>
 
-                <Row>
-                    <Col sm={6}>
-                        <Form.Group className="mb-3">
-                            <Form.Label>Avatar/Personenfoto</Form.Label>
-                            <Form.Control disabled={this.props.disabled} type="file" onChange={this.avatarChanged}/>
-                            <Form.Text>Gültige
-                                Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text>
-                            <br/>
-                            <Form.Text>Maximalgröße: {PersonaInfoComponent.MAXFILESIZE / 1000} MB</Form.Text>
+                <Form.Group className="mb-3">
+                    <Form.Label>Avatar/Personenfoto</Form.Label>
+                    <Form.Control disabled={this.props.disabled} type="file" onChange={this.avatarChanged}/>
+                    <Form.Text>Gültige
+                        Dateitypen: {PersonaInfoComponent.FILETYPES.map(i => "." + i).join(", ")}</Form.Text>
+                    <br/>
+                    <Form.Text>Maximalgröße: {PersonaInfoComponent.MAXFILESIZE / 1000} MB</Form.Text>
 
-                            <UIErrorBanner id={"avatar.empty"}/>
-                            <UIErrorBanner id={"avatar.size"}/>
-                            <UIErrorBanner id={"avatar.type"}/>
-                        </Form.Group>
-                    </Col>
-                    <Col sm={6}>
-                        <Form.Group className="mb-3">
-                            <Form.Label>Einkommen (Netto/Monat in €)</Form.Label>
-                            <Form.Control disabled={this.props.disabled} onInput={this.incomeChanged} type={"text"}
-                                          placeholder={"2400"}/>
-                            <UIErrorBanner id={"income.invalid"}/>
-                        </Form.Group>
-                    </Col>
-                </Row>
+                    <UIErrorBanner id={"avatar.empty"}/>
+                    <UIErrorBanner id={"avatar.size"}/>
+                    <UIErrorBanner id={"avatar.type"}/>
+                </Form.Group>
 
-                <Row>
-                    <Col sm={6}>
-                        <div className={"avatar-preview"}>
-                            <Image
-                                src={this.props.resourceManager.getBlobURL("avatar") ?? undefined}
-                                thumbnail rounded
-                                className={"avatar"} alt={"Avatar Vorschau"}/>
-                        </div>
-                    </Col>
-                    <Col sm={6}>
-                        <Form.Group className="mb-3">
-                            <Form.Label>Familienstand</Form.Label>
-                            <Form.Select
-                                disabled={this.props.disabled}
-                                onChange={this.onFamilyStatusChange}
-                                defaultValue={data?.familystatus}
-                            >
-                                <option value={0}>-- Auswählen --</option>
-                                {[...Array(4)].map((v, i) => {
-                                    return (
-                                        <option key={"family-status" + i} value={i + 1}>
-                                            {getFamilyStatus(i + 1)}
-                                        </option>
-                                    );
-                                })}
-                            </Form.Select>
-                        </Form.Group>
-                        <Form.Group className="mb-3">
-                            <Form.Label>Familie & Freunde</Form.Label>
-                            <CardComponent
-                                disabled={this.props.disabled}
-                                values={data?.family ?? []}
-                                max={PersonaInfoComponent.MAXFAMILY}
-                                min={PersonaInfoComponent.MINFAMILY}
-                                hideDesc
-                                required={false}
-                                counter={new NumberCounter()}
-                                name={"family"}
-                                onChanged={this.familyChanged}
-                            />
-
-                            <UIErrorBanner id={"family.length"}/>
-                        </Form.Group>
-                    </Col>
-                </Row>
+                <div className={"avatar-preview"}>
+                    <Image
+                        src={this.props.resourceManager.getBlobURL("avatar") ?? undefined}
+                        thumbnail rounded
+                        className={"avatar"} alt={"Avatar Vorschau"}/>
+                </div>
             </>
         );
     }
@@ -181,24 +106,6 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
         });
     }
 
-    incomeChanged = (e: ChangeEvent<HTMLInputElement>) => {
-        this.props.saveController.onChanged(save => {
-            let data = save.data["persona-info"];
-            if (data !== undefined) {
-                if (e.target.value.length <= 0) {
-                    data.income = null;
-                } else {
-                    let parsed = parseInt(e.target.value);
-                    if (isNaN(parsed)) {
-                        data.income = -1;
-                    } else {
-                        data.income = parsed;
-                    }
-                }
-            }
-        });
-    }
-
     avatarChanged = (e: ChangeEvent<HTMLInputElement>) => {
         let file: File | null = null;
         if (e.target.files !== null) {
@@ -210,19 +117,4 @@ export class PersonaInfoComponent extends Step<PersonaAnalysisValues, {}> {
         }
     }
 
-    private onFamilyStatusChange = (e: ChangeEvent<HTMLSelectElement>) => {
-        this.props.saveController.onChanged(save => {
-            if (save.data["persona-info"]) {
-                save.data["persona-info"].familystatus = e.target.selectedIndex;
-            }
-        });
-    }
-
-    private familyChanged = (fields: CardComponentFields) => {
-        this.props.saveController.onChanged(save => {
-            if (save.data["persona-info"]) {
-                save.data["persona-info"].family = fields;
-            }
-        });
-    }
 }

--- a/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonality.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonality.ts
@@ -26,34 +26,6 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
     extraWindow: ExtraWindowDefinition<PersonaAnalysisValues>;
     dataHandler: StepDataHandler<PersonaAnalysisValues>;
 
-    private properties = [
-        {
-            name: "demograph",
-            min: PersonaPersonalityComponent.MIN_DEMO,
-            max: PersonaPersonalityComponent.MAX_DEMO,
-        },
-        {
-            name: "pains",
-            min: PersonaPersonalityComponent.MIN_PAINS,
-            max: PersonaPersonalityComponent.MAX_PAINS,
-        },
-        {
-            name: "gains",
-            min: PersonaPersonalityComponent.MIN_GAINS,
-            max: PersonaPersonalityComponent.MAX_GAINS,
-        },
-        {
-            name: "statements",
-            min: PersonaPersonalityComponent.MIN_STATEMENTS,
-            max: PersonaPersonalityComponent.MAX_STATEMENTS,
-        },
-        {
-            name: "motives",
-            min: PersonaPersonalityComponent.MIN_MOTIVES,
-            max: PersonaPersonalityComponent.MAX_MOTIVES,
-        }
-    ];
-
     constructor() {
         this.id = "persona-personality";
         this.title = "2. Personalität kreieren";
@@ -68,28 +40,7 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
     isUnlocked = (data: PersonaAnalysisValues): boolean => data["persona-personality"] !== undefined;
 
     fillFromPreviousValues = (data: PersonaAnalysisValues): PersonaAnalysisValues => {
-        let d = this.properties.map((i) => i.name).reduce((a, v) => ({...a, [v]: []}), {}) as PersonaPersonalityValues;
-
-        d.fields = {
-            demograph: [],
-            pains: [],
-            gains: [],
-            statements: [],
-            motives: []
-        };
-
-        // generiere leere zeilen für min werte
-        for (const item of this.properties) {
-            for (let i = 0; i < item.min; i++) {
-                d.fields[item.name].push({
-                    name: "",
-                    desc: "",
-                    id: PersonaPersonalityComponent.COUNTER.get(i + 1)
-                });
-            }
-        }
-        d.individual = [];
-        data["persona-personality"] = d;
+        data["persona-personality"] = this.getDefault();
         return data;
     };
 
@@ -99,14 +50,18 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
 
     validateData = (data: PersonaAnalysisValues): UIError[] => {
         let errors = Array<UIError>();
-        let names = this.properties.map((item) => item.name);
         let d = data["persona-personality"];
 
         if (d) {
+            let names = Object.assign(
+                Object.fromEntries(Object.entries(d?.fields)),
+                Object.fromEntries(Object.entries(d?.fieldsElse))
+            );
+
             // Fields
-            for (const name of names) {
+            for (const [name, values] of Object.entries(names)) {
                 // empty
-                if (!isCardComponentFilled(d.fields[name], false)) {
+                if (!isCardComponentFilled(values, false)) {
                     errors.push({
                         id: `${name}.empty`,
                         message: "Bitte füllen Sie alle Felder aus!",
@@ -115,7 +70,7 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
                 }
 
                 // too long
-                if (isCardComponentTooLong(d.fields[name])) {
+                if (isCardComponentTooLong(values)) {
                     errors.push({
                         id: `${name}.toolong`,
                         message: "Einige Feld sind zu Lang!",
@@ -127,8 +82,23 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
             // Individuell
             validateCardComponentWithNameFilled(d.individual, "individual", errors);
         }
-
         return errors;
+    }
+
+    private getDefault = (): PersonaPersonalityValues => {
+        return {
+            fields: {
+                demograph: [],
+                pains: [],
+                gains: []
+            },
+            individual: [],
+            fieldsElse: {
+                statements: [],
+                motives: [],
+                keywords: []
+            }
+        };
     }
 
 

--- a/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonality.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonality.ts
@@ -54,8 +54,9 @@ export class PersonaPersonality implements StepDefinition<PersonaAnalysisValues>
 
         if (d) {
             let names = Object.assign(
-                Object.fromEntries(Object.entries(d?.fields)),
-                Object.fromEntries(Object.entries(d?.fieldsElse))
+                {},
+                d?.fields,
+                d?.fieldsElse
             );
 
             // Fields

--- a/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent-ti.ts
+++ b/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent-ti.ts
@@ -8,11 +8,14 @@ export const PersonaPersonalityValues = t.iface([], {
     "fields": t.iface([], {
         "demograph": "CardComponentFields",
         "pains": "CardComponentFields",
-        "gains": "CardComponentFields",
-        "statements": "CardComponentFields",
-        "motives": "CardComponentFields"
+        "gains": "CardComponentFields"
     }),
     "individual": "CardComponentFieldsWithName",
+    "fieldsElse": t.iface([], {
+        "statements": "CardComponentFields",
+        "motives": "CardComponentFields",
+        "keywords": "CardComponentFields"
+    })
 });
 
 const PersonaPersonality_ts: t.ITypeSuite = {

--- a/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent.tsx
@@ -176,7 +176,7 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
                         }}
                     />
 
-                    <h1 className={"mt-4"}>Sonstige Kategorien</h1>
+                    <h1 className={"mt-4"}>Weitere Kategorien</h1>
                     {this.renderItems(this.itemsElse, data.fieldsElse)}
                 </>
             );

--- a/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaPersonality/PersonaPersonalityComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {ReactNode} from "react";
 import {Step, StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {PersonaAnalysisValues} from "../../PersonaAnalysis";
 import {CardComponent, CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
@@ -9,19 +9,31 @@ import {
     CardComponentWithName
 } from "../../../../../general-components/CardComponent/CardComponentWithName";
 import {IconDefinition} from "@fortawesome/fontawesome-svg-core";
-import {faFire, faHeartbeat, faHeartBroken, faMicrophone, faUser} from "@fortawesome/free-solid-svg-icons";
-
+import {faFire, faHeartbeat, faHeartBroken, faMicrophone, faPen, faUser} from "@fortawesome/free-solid-svg-icons";
 
 export interface PersonaPersonalityValues {
     fields: {
         demograph: CardComponentFields,
         pains: CardComponentFields,
         gains: CardComponentFields,
+        [key: string]: CardComponentFields
+    }
+    individual: CardComponentFieldsWithName,
+    fieldsElse: {
         statements: CardComponentFields,
         motives: CardComponentFields,
-        [key: string]: CardComponentFields,
+        keywords: CardComponentFields,
+        [key: string]: CardComponentFields
     }
-    individual: CardComponentFieldsWithName
+}
+
+interface ItemsInterface {
+    legend: string,
+    name: string,
+    min: number,
+    max: number,
+    changeListener: (value: CardComponentFields) => void,
+    withDesc: boolean
 }
 
 export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}> {
@@ -29,8 +41,9 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
     static DEFAULT_MIN = 0;
     static DEFAULT_MAX = 5;
 
+    // VORGEGEBEN
     static MIN_DEMO = PersonaPersonalityComponent.DEFAULT_MIN;
-    static MAX_DEMO = PersonaPersonalityComponent.DEFAULT_MAX;
+    static MAX_DEMO = 6;
 
     static MIN_PAINS = PersonaPersonalityComponent.DEFAULT_MIN;
     static MAX_PAINS = PersonaPersonalityComponent.DEFAULT_MAX;
@@ -38,15 +51,20 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
     static MIN_GAINS = PersonaPersonalityComponent.DEFAULT_MIN;
     static MAX_GAINS = PersonaPersonalityComponent.DEFAULT_MAX;
 
+    // SONSTIGE
     static MIN_STATEMENTS = PersonaPersonalityComponent.DEFAULT_MIN;
-    static MAX_STATEMENTS = PersonaPersonalityComponent.DEFAULT_MAX;
+    static MAX_STATEMENTS = 3;
 
     static MIN_MOTIVES = PersonaPersonalityComponent.DEFAULT_MIN;
-    static MAX_MOTIVES = PersonaPersonalityComponent.DEFAULT_MAX;
+    static MAX_MOTIVES = 2;
+
+    static MIN_KEYWORDS = PersonaPersonalityComponent.DEFAULT_MIN;
+    static MAX_KEYWORDS = 2;
 
     static MIN_INDIVIDUAL = 0;
     static MAX_INDIVIDUAL = 5;
 
+    // INDIVIDUELL
     static MIN_INDIVIDUAL_CARDS = PersonaPersonalityComponent.DEFAULT_MIN;
     static MAX_INDIVIDUAL_CARDS = PersonaPersonalityComponent.DEFAULT_MAX;
 
@@ -56,56 +74,74 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
         "Pains (Frust, Probleme, Schmerzpunkte)",
         "Gains (Ziele, Wünsche, Gewinne)",
         "Statements (Zitate, Aussagen)",
-        "Dominierendes Grundmotiv"
+        "Dominierendes Grundmotiv und wie lässt sich dies erklären?",
+        "Wie lässt sich die Persona in ein/zwei Sätzen beschreiben?"
     ];
     public static icons: IconDefinition[] = [
         faUser,
         faHeartBroken,
         faHeartbeat,
         faMicrophone,
-        faFire
+        faFire,
+        faPen
     ];
     // Change listener
     private demoChanged = this.applyChanges.bind(this, "demo");
     private painsChanged = this.applyChanges.bind(this, "pain");
     private gainsChanged = this.applyChanges.bind(this, "gain");
-    private statementsChanged = this.applyChanges.bind(this, "state");
-    private motivesChanged = this.applyChanges.bind(this, "mot");
-    public items = [
+    public items: ItemsInterface[] = [
         {
             legend: PersonaPersonalityComponent.names[0],
             name: "demograph",
             min: PersonaPersonalityComponent.MIN_DEMO,
             max: PersonaPersonalityComponent.MAX_DEMO,
-            changeListener: this.demoChanged
+            changeListener: this.demoChanged,
+            withDesc: false
         },
         {
             legend: PersonaPersonalityComponent.names[1],
             name: "pains",
             min: PersonaPersonalityComponent.MIN_PAINS,
             max: PersonaPersonalityComponent.MAX_PAINS,
-            changeListener: this.painsChanged
+            changeListener: this.painsChanged,
+            withDesc: false
         },
         {
             legend: PersonaPersonalityComponent.names[2],
             name: "gains",
             min: PersonaPersonalityComponent.MIN_GAINS,
             max: PersonaPersonalityComponent.MAX_GAINS,
-            changeListener: this.gainsChanged
-        },
+            changeListener: this.gainsChanged,
+            withDesc: false
+        }
+    ];
+    private statementsChanged = this.applyChanges.bind(this, "state");
+    private motivesChanged = this.applyChanges.bind(this, "mot");
+    private keyWordsChanged = this.applyChanges.bind(this, "key");
+    public itemsElse = [
         {
             legend: PersonaPersonalityComponent.names[3],
             name: "statements",
             min: PersonaPersonalityComponent.MIN_STATEMENTS,
             max: PersonaPersonalityComponent.MAX_STATEMENTS,
-            changeListener: this.statementsChanged
+            changeListener: this.statementsChanged,
+            withDesc: false
         },
         {
             legend: PersonaPersonalityComponent.names[4],
             name: "motives",
             min: PersonaPersonalityComponent.MIN_MOTIVES,
             max: PersonaPersonalityComponent.MAX_MOTIVES,
-            changeListener: this.motivesChanged
+            changeListener: this.motivesChanged,
+            withDesc: true
+        },
+        {
+            legend: PersonaPersonalityComponent.names[5],
+            name: "keywords",
+            min: PersonaPersonalityComponent.MIN_KEYWORDS,
+            max: PersonaPersonalityComponent.MAX_KEYWORDS,
+            changeListener: this.keyWordsChanged,
+            withDesc: false
         }
     ];
 
@@ -115,40 +151,13 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
 
     build(): JSX.Element {
         let data = this.props.save.data["persona-personality"];
-
         if (data) {
             return (
                 <>
-                    <h1>Vorgeschriebene Felder</h1>
+                    <h1>Vorgeschriebene Kategorien</h1>
+                    {this.renderItems(this.items, data.fields)}
 
-                    {(this.items.map((item) => {
-                        if (data) {
-                            return (
-                                <fieldset key={`persona-item-${item.name}`}>
-                                    <legend>{item.legend}</legend>
-                                    <div>
-                                        <CardComponent
-                                            name={item.name}
-                                            values={data.fields[item.name]}
-                                            disabled={this.props.disabled}
-                                            min={item.min}
-                                            max={item.max}
-                                            counter={PersonaPersonalityComponent.COUNTER}
-                                            hideDesc={true}
-                                            required={true}
-                                            onChanged={item.changeListener}
-                                        />
-                                        <UIErrorBanner id={`${item.name}.empty`}/>
-                                        <UIErrorBanner id={`${item.name}.toolong`}/>
-                                    </div>
-                                </fieldset>
-                            );
-                        }
-                        return null;
-                    }))}
-
-                    <h1>Individuelle Felder (Maximal 5)</h1>
-
+                    <h1>Individuelle Kategorien (Maximal 5)</h1>
                     <CardComponentWithName
                         name={"individual"}
                         min={PersonaPersonalityComponent.MIN_INDIVIDUAL}
@@ -160,13 +169,47 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
                             hideDesc: true,
                             max: PersonaPersonalityComponent.MAX_INDIVIDUAL_CARDS,
                             min: PersonaPersonalityComponent.MIN_INDIVIDUAL_CARDS,
-                            counter: new NumberCounter()
+                            placeholder: {
+                                name: "Eintrag...",
+                                description: "Begründung"
+                            }
                         }}
                     />
+
+                    <h1 className={"mt-4"}>Sonstige Kategorien</h1>
+                    {this.renderItems(this.itemsElse, data.fieldsElse)}
                 </>
             );
         }
         return (<></>);
+    }
+
+    private renderItems = (items: ItemsInterface[], values: { [key: string]: CardComponentFields }): ReactNode => {
+        return items.map((item) => {
+            return (
+                <fieldset key={`persona-item-${item.name}`}>
+                    <legend>{item.legend}</legend>
+                    <div>
+                        <CardComponent
+                            name={item.name}
+                            values={values[item.name]}
+                            disabled={this.props.disabled}
+                            min={item.min}
+                            max={item.max}
+                            hideDesc={!item.withDesc}
+                            placeholder={{
+                                name: "Eintrag...",
+                                description: "Begründung"
+                            }}
+                            required={true}
+                            onChanged={item.changeListener}
+                        />
+                        <UIErrorBanner id={`${item.name}.empty`}/>
+                        <UIErrorBanner id={`${item.name}.toolong`}/>
+                    </div>
+                </fieldset>
+            );
+        });
     }
 
     private onIndividualChange = (values: CardComponentFieldsWithName) => {
@@ -178,7 +221,7 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
         });
     }
 
-    private applyChanges(type: "demo" | "pain" | "gain" | "state" | "mot", values: CardComponentFields) {
+    private applyChanges(type: "demo" | "pain" | "gain" | "state" | "mot" | "key", values: CardComponentFields) {
         this.props.saveController.onChanged(save => {
             const data = save.data["persona-personality"];
             if (data) {
@@ -193,10 +236,22 @@ export class PersonaPersonalityComponent extends Step<PersonaAnalysisValues, {}>
                         data.fields.gains = values;
                         break;
                     case "state":
-                        data.fields.statements = values;
+                        data.fieldsElse.statements = values.map(v => {
+                            let o = v;
+                            if (!o.name.startsWith('"')) {
+                                o.name = `"${o.name}`;
+                            }
+                            if (!o.name.endsWith('"')) {
+                                o.name = `${o.name}"`;
+                            }
+                            return o;
+                        });
                         break;
                     case "mot":
-                        data.fields.motives = values;
+                        data.fieldsElse.motives = values;
+                        break;
+                    case "key":
+                        data.fieldsElse.keywords = values;
                         break;
                 }
             }

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaInfoItem.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaInfoItem.tsx
@@ -9,7 +9,8 @@ import "./persona-info-item.scss";
 export interface PersonaInfoItemProps {
     title: string,
     icon?: IconDefinition,
-    items: CardComponentFields
+    items: CardComponentFields,
+    className?: string
 }
 
 function PersonaInfoItem(props: PersonaInfoItemProps) {
@@ -18,7 +19,7 @@ function PersonaInfoItem(props: PersonaInfoItemProps) {
     }
 
     return (
-        <div className={"info-container"}>
+        <div className={"info-container" + (props.className !== undefined ? ` ${props.className}` : "")}>
             <div className={"title"}>
                 {props.icon && (
                     <>
@@ -32,7 +33,11 @@ function PersonaInfoItem(props: PersonaInfoItemProps) {
                     {props.items.map((item, i) => {
                         return (
                             <ListGroupItem key={props.title + "-item-" + i}>
-                                {item.name}
+                                {item.name}{item.desc !== "" && (
+                                <>
+                                    : {item.desc}
+                                </>
+                            )}
                             </ListGroupItem>
                         );
                     })}

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
@@ -65,7 +65,7 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                     <Row>
                         <Col sm={6}>
                             <div className={"names"}>
-                                {info.firstname} {info.lastname}, {info.age} {info.age === 1 ? "Jahr" : "Jahre"} alt
+                                {info.firstname}, {info.age} {info.age === 1 ? "Jahr" : "Jahre"} alt
                             </div>
 
                             <div className={"avatar-container"}>

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
@@ -114,7 +114,9 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                     <ListGroup>
                         {props.values.map((data, index) => {
                             return (
-                                <ListGroupItem>
+                                <ListGroupItem
+                                    key={`list-group-item-${props.name}-${index}`}
+                                >
                                     {data}
                                 </ListGroupItem>
                             );

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
@@ -98,12 +98,6 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                             {this.getItemElements(right)}
                         </Col>
                     </Row>
-
-                    <PDFExporterPreview<PersonaAnalysisValues>
-                        save={this.props.save}
-                        exporter={new PersonaPDFExporter()}
-                        resources={this.props.resourceManager.resources}
-                    />
                 </>
             );
         }

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
@@ -1,16 +1,11 @@
-import React, {ReactNode} from "react";
+import React from "react";
 import {Step, StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {PersonaAnalysisValues} from "../../PersonaAnalysis";
-import {Col, Image, ListGroup, ListGroupItem, Row} from "react-bootstrap";
+import {Image} from "react-bootstrap";
 import {PersonaInfoItem} from "./PersonaInfoItem";
 import {CardComponentFieldsWithNameValues} from "../../../../../general-components/CardComponent/CardComponentWithName";
 import {IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import {PersonaPersonalityComponent} from "../PersonaPersonality/PersonaPersonalityComponent";
-import {faCoins, faUsers, faUserTag} from "@fortawesome/free-solid-svg-icons";
-import FAE from "../../../../../general-components/Icons/FAE";
-import {getFamilyStatus} from "../PersonaInfo/PersonaInfoComponent";
-import {PDFExporterPreview} from "../../../../../general-components/Export/PDF/PDFExporterPreview";
-import {PersonaPDFExporter} from "../../export/PersonaPDFExporter";
 
 export interface PersonaSummaryItem extends CardComponentFieldsWithNameValues {
     icon?: IconDefinition
@@ -19,7 +14,6 @@ export interface PersonaSummaryItem extends CardComponentFieldsWithNameValues {
 export type PersonaSummaryValues = null | undefined;
 
 export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
-    private i: number = 0;
 
     public constructor(props: StepProp<PersonaAnalysisValues>, context: any) {
         super(props, context);
@@ -30,115 +24,70 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
         let personality = this.props.save.data["persona-personality"];
 
         if (info && personality) {
-            let items: PersonaSummaryItem[] = [
-                ...Object.values(personality.fields).map<PersonaSummaryItem>((data, index) => {
-                    return {
-                        name: PersonaPersonalityComponent.names[index],
-                        fields: data,
-                        icon: PersonaPersonalityComponent.icons[index]
-                    };
-                }),
-                ...personality.individual
-            ];
-            let left: PersonaSummaryItem[] = [];
-            let right: PersonaSummaryItem[] = [];
-            items.forEach((v, i) => {
-                if (i % 2) {
-                    right.push(v);
-                } else {
-                    left.push(v);
-                }
-            });
-
-            let income: string | null = null;
-            if (info.income !== null) {
-                income = new Intl.NumberFormat(
-                    "de-DE",
-                    {
-                        style: "currency",
-                        currency: "EUR"
-                    }
-                ).format(info.income);
-            }
-
-            this.i = 0;
             return (
-                <>
-                    <Row>
-                        <Col sm={6}>
-                            <div className={"names"}>
-                                {info.firstname}, {info.age} {info.age === 1 ? "Jahr" : "Jahre"} alt
-                            </div>
+                <div className={"items"}>
+                    <div className={"avatar-item item"}>
+                        <div className={"names"}>
+                            {info.firstname}, {info.age} {info.age === 1 ? "Jahr" : "Jahre"} alt
+                        </div>
 
-                            <div className={"avatar-container"}>
-                                <Image className={"avatar"} rounded
-                                       src={this.props.resourceManager.getBlobURL("avatar") ?? undefined}/>
-                            </div>
+                        <div className={"avatar-container"}>
+                            <Image className={"avatar"} rounded
+                                   src={this.props.resourceManager.getBlobURL("avatar") ?? undefined}/>
+                        </div>
+                    </div>
+                    {Object.entries(personality.fields).map(([name, value], index) => {
+                        return (
+                            <PersonaInfoItem
+                                key={"persona-info-item-" + name}
+                                className={"item"}
+                                title={PersonaPersonalityComponent.names[index] ?? ""}
+                                icon={PersonaPersonalityComponent.icons[index] ?? undefined}
+                                items={value}
+                            />
+                        );
+                    })}
+                    {personality.individual.map(value => {
+                        return (
+                            <PersonaInfoItem
+                                key={"persona-info-item-" + value.name}
+                                className={"item"}
+                                title={value.name}
+                                items={value.fields}
+                            />
+                        )
+                    })}
+                    {Object.entries(personality.fieldsElse).map(([name, value], index) => {
+                        let values = value;
+                        // Sonderfall: Zitate
+                        if (index === 0) {
+                            values = value.map(v => {
+                                let value = Object.assign({}, v);
+                                if (!value.name.startsWith('"')) {
+                                    value.name = `"${value.name}`;
+                                }
+                                if (!value.name.endsWith('"')) {
+                                    value.name = `${value.name}"`;
+                                }
+                                return value;
+                            });
+                        }
 
-                            {this.getItemElements(left)}
-                        </Col>
-                        <Col sm={6}>
-                            {(income !== null) && (
-                                <this.InfoElement
-                                    icon={faCoins}
-                                    name={"Einkommen"}
-                                    values={[`Monatlicher Nettoverdienst von ${income}`]}
-                                />
-                            )}
-                            <this.InfoElement
-                                icon={faUserTag}
-                                name={"Familienstatus"}
-                                values={[getFamilyStatus(info.familystatus)]}
+                        let length = Object.keys(personality!.fields).length;
+                        return (
+                            <PersonaInfoItem
+                                key={"persona-info-item-" + name}
+                                className={"item"}
+                                title={PersonaPersonalityComponent.names[length + index] ?? ""}
+                                icon={PersonaPersonalityComponent.icons[length + index] ?? undefined}
+                                items={values}
                             />
-                            <this.InfoElement
-                                icon={faUsers}
-                                name={"Familie & Freunde"}
-                                values={info.family.length <= 0 ? ["Nicht angegeben"] : info.family.map<string>(i => i.name)}
-                            />
-                            {this.getItemElements(right)}
-                        </Col>
-                    </Row>
-                </>
+                        );
+                    })}
+                </div>
             );
         }
         return <></>;
-    }
-
-    public InfoElement(props: {
-        icon: IconDefinition,
-        name: string,
-        values: ReactNode[]
-    }) {
-        return (
-            <div className={"info-container"}>
-                <div className={"title"}><FAE icon={props.icon}/> {props.name}</div>
-                <div className={"content"}>
-                    <ListGroup>
-                        {props.values.map((data, index) => {
-                            return (
-                                <ListGroupItem key={`list-item-${index}-${props.name}`}>
-                                    {data}
-                                </ListGroupItem>
-                            );
-                        })}
-                    </ListGroup>
-                </div>
-            </div>
-        );
-    }
-
-    getItemElements = (items: PersonaSummaryItem[]): JSX.Element[] => {
-        return items.map((data) => {
-            this.i += 1;
-            return (
-                <PersonaInfoItem
-                    key={"personality-item-individual-" + this.i}
-                    title={data.name}
-                    icon={data.icon}
-                    items={data.fields}
-                />
-            );
-        });
     }
 
 }

--- a/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
+++ b/src/components/tools/persona-analysis/steps/PersonaSummary/PersonaSummaryComponent.tsx
@@ -9,8 +9,10 @@ import {PersonaPersonalityComponent} from "../PersonaPersonality/PersonaPersonal
 import {faCoins, faUsers, faUserTag} from "@fortawesome/free-solid-svg-icons";
 import FAE from "../../../../../general-components/Icons/FAE";
 import {getFamilyStatus} from "../PersonaInfo/PersonaInfoComponent";
+import {PDFExporterPreview} from "../../../../../general-components/Export/PDF/PDFExporterPreview";
+import {PersonaPDFExporter} from "../../export/PersonaPDFExporter";
 
-interface Item extends CardComponentFieldsWithNameValues {
+export interface PersonaSummaryItem extends CardComponentFieldsWithNameValues {
     icon?: IconDefinition
 }
 
@@ -28,8 +30,8 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
         let personality = this.props.save.data["persona-personality"];
 
         if (info && personality) {
-            let items: Item[] = [
-                ...Object.values(personality.fields).map<Item>((data, index) => {
+            let items: PersonaSummaryItem[] = [
+                ...Object.values(personality.fields).map<PersonaSummaryItem>((data, index) => {
                     return {
                         name: PersonaPersonalityComponent.names[index],
                         fields: data,
@@ -38,8 +40,8 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                 }),
                 ...personality.individual
             ];
-            let left: Item[] = [];
-            let right: Item[] = [];
+            let left: PersonaSummaryItem[] = [];
+            let right: PersonaSummaryItem[] = [];
             items.forEach((v, i) => {
                 if (i % 2) {
                     right.push(v);
@@ -96,6 +98,12 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                             {this.getItemElements(right)}
                         </Col>
                     </Row>
+
+                    <PDFExporterPreview<PersonaAnalysisValues>
+                        save={this.props.save}
+                        exporter={new PersonaPDFExporter()}
+                        resources={this.props.resourceManager.resources}
+                    />
                 </>
             );
         }
@@ -114,9 +122,7 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
                     <ListGroup>
                         {props.values.map((data, index) => {
                             return (
-                                <ListGroupItem
-                                    key={`list-group-item-${props.name}-${index}`}
-                                >
+                                <ListGroupItem key={`list-item-${index}-${props.name}`}>
                                     {data}
                                 </ListGroupItem>
                             );
@@ -127,7 +133,7 @@ export class PersonaSummaryComponent extends Step<PersonaAnalysisValues, {}> {
         );
     }
 
-    getItemElements = (items: Item[]): JSX.Element[] => {
+    getItemElements = (items: PersonaSummaryItem[]): JSX.Element[] => {
         return items.map((data) => {
             this.i += 1;
             return (

--- a/src/components/tools/test-analysis/extraWindow/TestSubstepsExtraWindow.tsx
+++ b/src/components/tools/test-analysis/extraWindow/TestSubstepsExtraWindow.tsx
@@ -2,6 +2,7 @@ import {ExtraWindowComponent} from "../../../../general-components/Tool/ExtraWin
 import {TestAnalysisValues} from "../TestAnalysis";
 
 import "./test-substeps-extra-window.scss";
+import {ProgressBar} from "react-bootstrap";
 
 interface TestSubstepsExtraWindowState {
 
@@ -10,9 +11,21 @@ interface TestSubstepsExtraWindowState {
 class TestSubstepsExtraWindow extends ExtraWindowComponent<TestAnalysisValues, TestSubstepsExtraWindowState> {
 
     render() {
+        let ratings = this.props.data["test-substeps"]!.ratings;
+        let current = ratings.length;
         return (
             <>
-                Hallo Welt!
+                <b>Fortschritt:</b>
+                <ProgressBar
+                    min={0}
+                    now={current}
+                    max={9}
+                    striped
+                    animated
+                    variant={"primary"}
+                />
+                Aktueller Unterschritt: {current} / 10 <br/>
+                Durchschnittsbewertung: {ratings.reduce((a, b) => a + b, 0) / current}
             </>
         )
     }

--- a/src/components/tools/test-analysis/steps/TestSubsteps/TestSubsteps.ts
+++ b/src/components/tools/test-analysis/steps/TestSubsteps/TestSubsteps.ts
@@ -1,4 +1,5 @@
 import {
+    CustomNextButton,
     ExtraWindowDefinition,
     StepDataHandler,
     StepDefinition,
@@ -19,6 +20,7 @@ class TestSubsteps implements StepDefinition<TestAnalysisValues>, StepDataHandle
     dataHandler: StepDataHandler<TestAnalysisValues>;
     extraWindow: ExtraWindowDefinition<TestAnalysisValues>;
     subStep: SubStepDefinition<TestAnalysisValues>;
+    customNextButton: CustomNextButton
 
     constructor() {
         this.id = "test-substeps";
@@ -30,6 +32,7 @@ class TestSubsteps implements StepDefinition<TestAnalysisValues>, StepDataHandle
             extraWindowComponent: TestSubstepsExtraWindow,
         };
         this.subStep = this;
+        this.customNextButton = {text: "Nächster"};
     }
 
     deleteData(data: Draft<TestAnalysisValues>): void {
@@ -37,7 +40,9 @@ class TestSubsteps implements StepDefinition<TestAnalysisValues>, StepDataHandle
     }
 
     fillFromPreviousValues(data: Draft<TestAnalysisValues>): void {
-        data["test-substeps"] = {};
+        data["test-substeps"] = {
+            ratings: [0]
+        };
     }
 
     isUnlocked(data: TestAnalysisValues): boolean {
@@ -54,18 +59,25 @@ class TestSubsteps implements StepDefinition<TestAnalysisValues>, StepDataHandle
     }
 
     getStepCount(data: TestAnalysisValues): number {
-        return 0;
+        return 10;
     }
 
     isStepUnlocked(subStep: number, data: TestAnalysisValues): boolean {
-        return false;
+        return subStep < 1 || this.validateStep(subStep - 1, data).length === 0;
     }
 
     validateStep(subStep: number, data: TestAnalysisValues): UIError[] {
         let errors: UIError[] = [];
 
         // Validierung
-        // ...
+        let ratings = data["test-substeps"]?.ratings;
+        if (ratings && ratings.length <= subStep) {
+            errors.push({
+               level: "error",
+               id: "rating.empty",
+               message: "Bitte geben Sie eine Bewertung an!"
+            });
+        }
 
         return errors;
     }

--- a/src/components/tools/test-analysis/steps/TestSubsteps/TestSubsteps.ts
+++ b/src/components/tools/test-analysis/steps/TestSubsteps/TestSubsteps.ts
@@ -73,9 +73,9 @@ class TestSubsteps implements StepDefinition<TestAnalysisValues>, StepDataHandle
         let ratings = data["test-substeps"]?.ratings;
         if (ratings && ratings.length <= subStep) {
             errors.push({
-               level: "error",
-               id: "rating.empty",
-               message: "Bitte geben Sie eine Bewertung an!"
+                level: "error",
+                id: "rating.empty",
+                message: "Bitte geben Sie eine Bewertung an!"
             });
         }
 

--- a/src/components/tools/test-analysis/steps/TestSubsteps/TestSubstepsComponent.tsx
+++ b/src/components/tools/test-analysis/steps/TestSubsteps/TestSubstepsComponent.tsx
@@ -1,8 +1,10 @@
 import {Step, StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {TestAnalysisValues} from "../../TestAnalysis";
+import {Form, FormGroup, Image} from "react-bootstrap";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 
 export interface TestSubstepsValues {
-
+    ratings: number[]
 }
 
 interface TestSubstepsComponentState {
@@ -16,11 +18,47 @@ class TestSubstepsComponent extends Step<TestAnalysisValues, TestSubstepsCompone
     }
 
     protected build(): JSX.Element {
-        return (
-            <>
-                Hallo Welt!
-            </>
-        );
+        let ratings = this.props.save.data["test-substeps"]?.ratings;
+
+        if (ratings) {
+            return (
+                <>
+                    <h3>Bitte bewerten Sie folgendes Bild:</h3>
+
+                    <Image
+                        className={"mt-3"}
+                        thumbnail
+                        rounded
+                        src={`https://picsum.photos/600/300?${this.props.currentSubStep}`}
+                    />
+
+                    <FormGroup
+                        className={"mt-3"}
+                    >
+                        <Form.Label>
+                            Bewertung ({ratings[this.props.currentSubStep]})
+                        </Form.Label>
+
+                        <Form.Range
+                            min={0}
+                            max={10}
+                            disabled={this.props.disabled}
+                            value={ratings[this.props.currentSubStep]}
+                            onChange={(e) => {
+                                this.props.saveController.onChanged(save => {
+                                    let ratings = save.data["test-substeps"]!.ratings;
+                                    ratings[this.props.currentSubStep] = Number(e.target.value);
+                                    save.data["test-substeps"]!.ratings = ratings;
+                                });
+                            }}
+                        />
+
+                        <UIErrorBanner id={"rating.empty"} />
+                    </FormGroup>
+                </>
+            );
+        }
+        return <></>;
     }
 
 }

--- a/src/components/tools/test-analysis/steps/TestSubsteps/TestSubstepsComponent.tsx
+++ b/src/components/tools/test-analysis/steps/TestSubsteps/TestSubstepsComponent.tsx
@@ -53,7 +53,7 @@ class TestSubstepsComponent extends Step<TestAnalysisValues, TestSubstepsCompone
                             }}
                         />
 
-                        <UIErrorBanner id={"rating.empty"} />
+                        <UIErrorBanner id={"rating.empty"}/>
                     </FormGroup>
                 </>
             );

--- a/src/general-components/CardComponent/CardComponent.tsx
+++ b/src/general-components/CardComponent/CardComponent.tsx
@@ -72,19 +72,22 @@ class CardComponent<D extends object> extends PureComponent<CardComponentProps<D
 
         return this.props.values.map((value, index) => {
             return (
-                <Card<D> id={value.id}
-                         key={value.id + "-" + index}
-                         name={this.props.name}
-                         value={value.name}
-                         desc={value.desc}
-                         disabled={this.props.disabled}
-                         required={required}
-                         index={index}
-                         hideDesc={this.props.hideDesc ?? false}
-                         onDelete={this.removeCard.bind(this, index)}
-                         onChange={this.cardUpdatedListener}
-                         customDescValues={value.extra}
-                         customDescs={this.props.customDescriptions}/>
+                <Card<D>
+                    id={value.id}
+                    key={value.id + "-" + index}
+                    name={this.props.name}
+                    value={value.name}
+                    desc={value.desc}
+                    disabled={this.props.disabled}
+                    required={required}
+                    index={index}
+                    hideDesc={this.props.hideDesc ?? false}
+                    onDelete={this.removeCard.bind(this, index)}
+                    onChange={this.cardUpdatedListener}
+                    customDescValues={value.extra}
+                    customDescs={this.props.customDescriptions}
+                    placeholder={this.props.placeholder}
+                />
             );
         });
     }

--- a/src/general-components/CardComponent/CardComponentWithName.tsx
+++ b/src/general-components/CardComponent/CardComponentWithName.tsx
@@ -1,6 +1,11 @@
 import React, {ChangeEvent, PureComponent} from "react";
 import "./card-component-with-name.scss";
-import {CardComponent, CardComponentFields, isCardComponentFilled} from "./CardComponent";
+import {
+    CardComponent,
+    CardComponentFieldPlaceholder,
+    CardComponentFields,
+    isCardComponentFilled
+} from "./CardComponent";
 import FAE from "../Icons/FAE";
 import {faPlus, faTimes} from "@fortawesome/free-solid-svg-icons";
 import {Button, Card as BootstrapCard, Form, InputGroup} from "react-bootstrap";
@@ -20,7 +25,8 @@ export interface CardComponentControlProps {
     min: number,
     max: number,
     hideDesc: boolean,
-    counter?: CounterInterface
+    counter?: CounterInterface,
+    placeholder?: CardComponentFieldPlaceholder
 }
 
 export interface CardComponentWithNameProps<D = any> {
@@ -76,6 +82,7 @@ class CardComponentWithName<D extends object> extends PureComponent<CardComponen
                                     hideDesc={this.props.cardComponent.hideDesc}
                                     disabled={this.props.disabled}
                                     counter={this.props.cardComponent.counter}
+                                    placeholder={this.props.cardComponent.placeholder}
                                     onChanged={(values) => {
                                         this.registerUpdate(index, data.name, values);
                                     }}

--- a/src/general-components/Export/ExcelExporter.tsx
+++ b/src/general-components/Export/ExcelExporter.tsx
@@ -1,6 +1,7 @@
 import {Exporter} from "./Exporter";
 import {SaveResource} from "../Datastructures";
 import XLSX, {BookType, CellObject, CellStyle, WorkBook, WorkSheet} from "xlsx-js-style";
+import {SingleMessageProps} from "../Messages/Messages";
 
 
 abstract class ExcelExporter<D> extends Exporter<D> {
@@ -39,7 +40,7 @@ abstract class ExcelExporter<D> extends Exporter<D> {
         return o !== undefined && Object.keys(o).length > 0;
     }
 
-    protected onExport(data: SaveResource<D>): BlobPart[] {
+    protected async onExport(data: SaveResource<D>): Promise<BlobPart[]> {
         // create new workbook
         this.workbook = XLSX.utils.book_new();
 
@@ -51,11 +52,15 @@ abstract class ExcelExporter<D> extends Exporter<D> {
             type: "array",
             Props: {
                 Title: data.name,
-                Author: "Strategietools",
+                Author: "Strategienavigator",
             },
             cellStyles: true,
         });
         return [buffer];
+    }
+
+    public validateExport(data: SaveResource<D>): SingleMessageProps[] {
+        return [];
     }
 
     protected updateWidth = (variable: number, w: number) => {

--- a/src/general-components/Export/ExcelExporter.tsx
+++ b/src/general-components/Export/ExcelExporter.tsx
@@ -36,6 +36,10 @@ abstract class ExcelExporter<D> extends Exporter<D> {
         return parseInt(row.substr(1, row.length));
     }
 
+    public validateExport(data: SaveResource<D>): SingleMessageProps[] {
+        return [];
+    }
+
     protected isFilled = <D extends object>(o?: D): o is D => {
         return o !== undefined && Object.keys(o).length > 0;
     }
@@ -57,10 +61,6 @@ abstract class ExcelExporter<D> extends Exporter<D> {
             cellStyles: true,
         });
         return [buffer];
-    }
-
-    public validateExport(data: SaveResource<D>): SingleMessageProps[] {
-        return [];
     }
 
     protected updateWidth = (variable: number, w: number) => {

--- a/src/general-components/Export/Exporter.ts
+++ b/src/general-components/Export/Exporter.ts
@@ -1,6 +1,7 @@
 import FileSaver from "file-saver";
 import {SaveResource} from "../Datastructures";
 import {Messages, SingleMessageProps} from "../Messages/Messages";
+import {ResourcesType} from "../Tool/ToolSavePage/ToolSavePage";
 
 
 abstract class Exporter<D> {
@@ -30,10 +31,11 @@ abstract class Exporter<D> {
         return this.fileType;
     }
 
-    public export = async (save: SaveResource<D>): Promise<void> => {
-        let validate = this.validateExport(save);
+    public export = async (save: SaveResource<D>, resources: ResourcesType): Promise<void> => {
+        console.log(resources)
+        let validate = this.validateExport(save, resources);
         if (validate.length <= 0) {
-            const blobPart = await this.onExport(save);
+            const blobPart = await this.onExport(save, resources);
             const blob = new Blob(blobPart, {
                 type: this.fileType
             });
@@ -46,8 +48,9 @@ abstract class Exporter<D> {
         }
     }
 
-    protected abstract validateExport(data: SaveResource<D>): SingleMessageProps[];
-    protected abstract onExport(data: SaveResource<D>): Promise<BlobPart[]>;
+    protected abstract validateExport(save: SaveResource<D>, resources: ResourcesType): SingleMessageProps[];
+
+    protected abstract onExport(save: SaveResource<D>, resources: ResourcesType): Promise<BlobPart[]>;
 
     /**
      * Öffnet Download Dialog und startet Download

--- a/src/general-components/Export/Exporter.ts
+++ b/src/general-components/Export/Exporter.ts
@@ -32,7 +32,6 @@ abstract class Exporter<D> {
     }
 
     public export = async (save: SaveResource<D>, resources: ResourcesType): Promise<void> => {
-        console.log(resources)
         let validate = this.validateExport(save, resources);
         if (validate.length <= 0) {
             const blobPart = await this.onExport(save, resources);

--- a/src/general-components/Export/Exporter.ts
+++ b/src/general-components/Export/Exporter.ts
@@ -1,5 +1,6 @@
 import FileSaver from "file-saver";
 import {SaveResource} from "../Datastructures";
+import {Messages, SingleMessageProps} from "../Messages/Messages";
 
 
 abstract class Exporter<D> {
@@ -29,15 +30,24 @@ abstract class Exporter<D> {
         return this.fileType;
     }
 
-    public export(save: SaveResource<D>): void {
-        const blobPart = this.onExport(save);
-        const blob = new Blob(blobPart, {
-            type: this.fileType
-        });
-        this.save(blob, save.name);
+    public export = async (save: SaveResource<D>): Promise<void> => {
+        let validate = this.validateExport(save);
+        if (validate.length <= 0) {
+            const blobPart = await this.onExport(save);
+            const blob = new Blob(blobPart, {
+                type: this.fileType
+            });
+            this.save(blob, save.name);
+        } else {
+            // Print error Messages
+            validate.forEach((msg) => {
+                Messages.addWithProps(msg);
+            });
+        }
     }
 
-    protected abstract onExport(data: SaveResource<D>): BlobPart[];
+    protected abstract validateExport(data: SaveResource<D>): SingleMessageProps[];
+    protected abstract onExport(data: SaveResource<D>): Promise<BlobPart[]>;
 
     /**
      * Öffnet Download Dialog und startet Download

--- a/src/general-components/Export/JSONExporter.tsx
+++ b/src/general-components/Export/JSONExporter.tsx
@@ -1,5 +1,6 @@
 import {Exporter} from "./Exporter";
 import {SaveResource} from "../Datastructures";
+import {SingleMessageProps} from "../Messages/Messages";
 
 
 class JSONExporter<D> extends Exporter<D> {
@@ -8,7 +9,11 @@ class JSONExporter<D> extends Exporter<D> {
         super("JSON", "json", "application/json");
     }
 
-    protected onExport(data: SaveResource<D>): BlobPart[] {
+    public validateExport(data: SaveResource<D>): SingleMessageProps[] {
+        return [];
+    }
+
+    protected async onExport(data: SaveResource<D>): Promise<BlobPart[]> {
         return [JSON.stringify(data.data, null, 4)];
     }
 }

--- a/src/general-components/Export/JSONExporter.tsx
+++ b/src/general-components/Export/JSONExporter.tsx
@@ -1,20 +1,21 @@
 import {Exporter} from "./Exporter";
 import {SaveResource} from "../Datastructures";
 import {SingleMessageProps} from "../Messages/Messages";
+import {ResourcesType} from "../Tool/ToolSavePage/ToolSavePage";
 
 
 class JSONExporter<D> extends Exporter<D> {
 
-    constructor() {
+    public constructor() {
         super("JSON", "json", "application/json");
     }
 
-    public validateExport(data: SaveResource<D>): SingleMessageProps[] {
-        return [];
+    protected onExport = async (data: SaveResource<D>): Promise<BlobPart[]> => {
+        return [JSON.stringify(data.data, null, 4)];
     }
 
-    protected async onExport(data: SaveResource<D>): Promise<BlobPart[]> {
-        return [JSON.stringify(data.data, null, 4)];
+    protected validateExport(save: SaveResource<D>, resources: ResourcesType): SingleMessageProps[] {
+        return [];
     }
 }
 

--- a/src/general-components/Export/PDF/PDFExporter.tsx
+++ b/src/general-components/Export/PDF/PDFExporter.tsx
@@ -65,8 +65,12 @@ abstract class PDFExporter<D> extends Exporter<D> {
         this.height += padding;
     }
 
-    protected CalculateTextHeight(doc: jsPDF, text: string, fontSize?: number) {
-        this.height += doc.getTextDimensions(text, {fontSize: fontSize ?? this.fontSize}).h;
+    protected CalculateTextHeight(doc: jsPDF, text: string, fontSize?: number, multiply?: number) {
+        let add = doc.getTextDimensions(text, {fontSize: fontSize ?? this.fontSize}).h;
+        if (multiply) {
+            add *= multiply;
+        }
+        this.height += add;
         return this.height;
     }
 

--- a/src/general-components/Export/PDF/PDFExporter.tsx
+++ b/src/general-components/Export/PDF/PDFExporter.tsx
@@ -1,0 +1,190 @@
+import {Exporter} from "../Exporter";
+import {SaveResource} from "../../Datastructures";
+import jsPDF from "jspdf";
+import {Tools} from "../../../components/platform/home/Home";
+import {ResourcesType} from "../../Tool/ToolSavePage/ToolSavePage";
+
+export interface PDFMargins {
+    top: number
+    right: number
+    bottom: number
+    left: number
+}
+
+abstract class PDFExporter<D> extends Exporter<D> {
+    public height: number;
+    private MARGINS = {
+        top: 7,
+        right: 7,
+        bottom: 7,
+        left: 7
+    }
+    private title: string = "Ihr PDF";
+    private readonly fontSize: number = 12;
+
+    public constructor(options?: {
+        margins?: PDFMargins,
+        defaultFontSize?: number
+    }) {
+        super("PDF", "pdf", "application/pdf");
+        if (options) {
+            if (options.margins) {
+                this.MARGINS = options.margins;
+            }
+            if (options.defaultFontSize) {
+                this.fontSize = options.defaultFontSize;
+            }
+        }
+        this.height = 30;
+    }
+
+    public abstract buildPDF(doc: jsPDF, save: SaveResource<D>, resources: ResourcesType): Promise<void>;
+
+    public onExport = async (save: SaveResource<D>, resources: ResourcesType): Promise<BlobPart[]> => {
+        let doc = new jsPDF({
+            compress: true
+        });
+
+        // Set default settings
+        doc.setLanguage("de-DE");
+        doc.setTextColor(0, 0, 0, 0.9);
+        doc.setFontSize(this.fontSize);
+        doc.setFont("Helvetica");
+
+        await this.buildPDF(doc, save, resources);
+        doc = this.addPDFStandardLook(doc, save);
+
+        return [doc.output("blob")];
+    }
+
+    protected CalculateImageHeight(doc: jsPDF) {
+        return this.height;
+    }
+
+    protected addHeightPadding(padding: number) {
+        this.height += padding;
+    }
+
+    protected CalculateTextHeight(doc: jsPDF, text: string, fontSize?: number) {
+        this.height += doc.getTextDimensions(text, {fontSize: fontSize ?? this.fontSize}).h;
+        return this.height;
+    }
+
+    protected getWidth(doc: jsPDF, w: number): number {
+        let {width} = doc.internal.pageSize;
+        return Math.min(width - this.MARGINS.right, w + this.MARGINS.left);
+    }
+
+    protected async getImageSizes(blob: Blob, maxHeight?: number, maxWidth?: number) {
+        let bmap = await createImageBitmap(blob);
+        let {width, height} = bmap;
+        bmap.close();
+
+        if (maxHeight && height > maxHeight) {
+            let wRatio = width / height;
+            height = Math.min(maxHeight, height);
+            width = height * wRatio;
+        }
+        if (maxWidth && width > maxWidth) {
+            let hRatio = height / width;
+            width = Math.min(maxWidth, width);
+            height = width * hRatio;
+        }
+
+        return {
+            width: width,
+            height: height
+        }
+    }
+
+    protected setTitle(title: string) {
+        this.title = title;
+    }
+
+    private addPDFStandardLook(doc: jsPDF, save: SaveResource<D>): jsPDF {
+        let {width, height} = doc.internal.pageSize;
+        let pageCount = doc.getNumberOfPages();
+
+        doc.setTextColor(0, 0, 0, 0.75);
+        doc.setFontSize(10);
+        for (let i = 1; i <= pageCount; i++) {
+            doc.setPage(i);
+
+            // Fußzeile
+            let pageText = `Seite ${i} von ${pageCount}`;
+            doc.text(
+                pageText,
+                width - doc.getTextDimensions(pageText, {fontSize: 10}).w - this.MARGINS.right,
+                height - doc.getTextDimensions(pageText, {fontSize: 10}).h,
+                {
+                    baseline: "bottom"
+                }
+            );
+
+            // Kopfzeile
+            // Tool-name
+            let toolname = `${Tools.find(v => v.id === save.tool_id)?.name ?? "Analyse"}`;
+            doc.text(
+                toolname,
+                this.MARGINS.left,
+                this.MARGINS.top,
+                {
+                    baseline: "top"
+                }
+            );
+
+            // Save-name
+            let savename = `${save.name}`;
+            doc.text(
+                savename,
+                (width / 2) - (doc.getTextWidth(savename) / 2) - this.MARGINS.right + this.MARGINS.left,
+                this.MARGINS.top,
+                {
+                    baseline: "top"
+                }
+            );
+            // Datum
+            let date = new Date().toLocaleDateString("de-DE");
+            doc.text(
+                date,
+                width - doc.getTextWidth(date) - this.MARGINS.right,
+                this.MARGINS.top,
+                {
+                    baseline: "top"
+                }
+            );
+        }
+
+        let h = this.MARGINS.top + 13;
+        // Füge Titel hinzu
+        doc.setTextColor(0, 0, 0, 0.9);
+        doc.setFontSize(16);
+        doc.setFont("Helvetica", "bold");
+
+        doc.setPage(1);
+        doc.text(
+            this.title,
+            this.MARGINS.left,
+            h,
+        );
+        doc.setFont("Helvetica", "normal");
+        h += doc.getTextDimensions(this.title, {fontSize: 16}).h;
+
+        doc.setFontSize(10);
+        doc.setTextColor(0, 0, 0, 0.5);
+        doc.line(
+            this.MARGINS.left,
+            h,
+            width - this.MARGINS.right,
+            h,
+            "S"
+        );
+        doc.setTextColor(0, 0, 0, 0.9);
+        return doc;
+    }
+
+}
+
+export {
+    PDFExporter
+}

--- a/src/general-components/Export/PDF/PDFExporter.tsx
+++ b/src/general-components/Export/PDF/PDFExporter.tsx
@@ -121,6 +121,17 @@ abstract class PDFExporter<D> extends Exporter<D> {
                 }
             );
 
+            let linkText = "Erstellt mit dem Strategienavigator";
+            doc.textWithLink(
+                linkText,
+                this.MARGINS.left,
+                height - doc.getTextDimensions(linkText, {fontSize: 10}).h,
+                {
+                    baseline: "bottom",
+                    url: 'https://strategie-navigator.jade-hs.de/'
+                }
+            );
+
             // Kopfzeile
             // Tool-name
             let toolname = `${Tools.find(v => v.id === save.tool_id)?.name ?? "Analyse"}`;

--- a/src/general-components/Export/PDF/PDFExporterPreview.tsx
+++ b/src/general-components/Export/PDF/PDFExporterPreview.tsx
@@ -1,0 +1,40 @@
+import {Component} from "react";
+import {SaveResource} from "../../Datastructures";
+import {PDFExporter} from "./PDFExporter";
+import {ResourcesType} from "../../Tool/ToolSavePage/ToolSavePage";
+
+interface PDFExporterPreviewProps<D> {
+    save: SaveResource<D>,
+    exporter: PDFExporter<D>,
+    resources: ResourcesType
+}
+
+class PDFExporterPreview<D> extends Component<PDFExporterPreviewProps<D>, { url: string }> {
+    state = {
+        url: ""
+    }
+
+    render = () => {
+        return (
+            <iframe
+                title={"PDF-Export-Vorschau"}
+                width="100%"
+                height="900px"
+                src={this.state.url}
+            ></iframe>
+        );
+    }
+
+    componentDidMount = async () => {
+        URL.revokeObjectURL(this.state.url);
+        let parts: BlobPart[] = await this.props.exporter.onExport(this.props.save, this.props.resources);
+        this.setState({
+            url: parts.length > 0 ? URL.createObjectURL(parts[0]) : ""
+        });
+    }
+
+}
+
+export {
+    PDFExporterPreview
+}

--- a/src/general-components/Export/PDFExporter.tsx
+++ b/src/general-components/Export/PDFExporter.tsx
@@ -1,0 +1,67 @@
+import {Exporter} from "./Exporter";
+import {SaveResource} from "../Datastructures";
+import jsPDF from "jspdf";
+import {SingleMessageProps} from "../Messages/Messages";
+
+class PDFExporter<D> extends Exporter<D> {
+    private readonly element: string;
+    private readonly validateFunction: (data: SaveResource<D>) => SingleMessageProps[];
+
+    constructor(element: string, validate: (data: SaveResource<D>) => SingleMessageProps[]) {
+        super("PDF", "pdf", "application/pdf");
+        this.element = element;
+        this.validateFunction = validate;
+    }
+
+    public buildPDF(doc: jsPDF): jsPDF | undefined {
+        return undefined;
+    }
+
+    protected onExport = async (data: SaveResource<D>): Promise<BlobPart[]> => {
+        let pdf = new jsPDF({
+            unit: "px",
+            compress: true
+        });
+        pdf.setLanguage("de-DE");
+
+        let pdfNew = this.buildPDF(pdf);
+        let output: Blob | string = "";
+
+        if (!pdfNew) {
+            // Hole HTML-Element
+            let element = this.getHTMLElement();
+            if (element != null) {
+                // Baue PDF
+                let worker = pdf.html(element, {
+                    jsPDF: pdf,
+                    filename: `${this.getName()}.${this.getFileExtension()}`,
+                    callback: (doc) => {
+                        output = doc.output("blob")
+                    },
+                    margin: [10, 10, 10, 10]
+                });
+                await worker.doCallback();
+            }
+        } else {
+
+        }
+        return [output];
+    }
+
+    private getHTMLElement() {
+        let element = document.querySelector<HTMLElement>(this.element);
+        if (element == null) {
+            console.error(`HTML Element "${this.element}" not found!`);
+        }
+        return element;
+    }
+
+    protected validateExport(data: SaveResource<D>): SingleMessageProps[] {
+        return this.validateFunction(data);
+    }
+
+}
+
+export {
+    PDFExporter
+}

--- a/src/general-components/Export/PDFExporter.tsx
+++ b/src/general-components/Export/PDFExporter.tsx
@@ -48,16 +48,16 @@ class PDFExporter<D> extends Exporter<D> {
         return [output];
     }
 
+    protected validateExport(data: SaveResource<D>): SingleMessageProps[] {
+        return this.validateFunction(data);
+    }
+
     private getHTMLElement() {
         let element = document.querySelector<HTMLElement>(this.element);
         if (element == null) {
             console.error(`HTML Element "${this.element}" not found!`);
         }
         return element;
-    }
-
-    protected validateExport(data: SaveResource<D>): SingleMessageProps[] {
-        return this.validateFunction(data);
     }
 
 }

--- a/src/general-components/Messages/Messages.tsx
+++ b/src/general-components/Messages/Messages.tsx
@@ -62,6 +62,12 @@ class Messages extends Component<MessagesProps, any> {
         reload_app();
     }
 
+    static addWithProps(values: SingleMessageProps) {
+        Messages.messages.push(<SingleMessage key={Messages.messages.length} content={values.content} type={values.type}
+                                              timer={values.timer}/>);
+        reload_app();
+    }
+
     render = () => {
         return (
             <div style={this.props.style}

--- a/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
+++ b/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
@@ -335,8 +335,8 @@ class StepComponent<D extends object> extends Component<StepComponentProps<D> & 
             if (validated) {
                 // force for performance reasons (no duplicate check of validation)
                 this.nextSubStep(true);
-                return;
             }
+            return;
         }
 
         const validated = this.validateStep(this.state.currentStep);

--- a/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
+++ b/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
@@ -367,7 +367,10 @@ class StepComponent<D extends object> extends Component<StepComponentProps<D> & 
     }
 
     private onExport = (exporter: Exporter<D>) => {
-        exporter.export(this.props.save).then(() => {
+        exporter.export(
+            this.props.save,
+            this.props.resourceManager.resources
+        ).then(() => {
             this.setState({
                 showExportModal: false
             });

--- a/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
+++ b/src/general-components/Tool/SteppableTool/StepComponent/StepComponent.tsx
@@ -367,10 +367,10 @@ class StepComponent<D extends object> extends Component<StepComponentProps<D> & 
     }
 
     private onExport = (exporter: Exporter<D>) => {
-        exporter.export(this.props.save);
-
-        this.setState({
-            showExportModal: false
+        exporter.export(this.props.save).then(() => {
+            this.setState({
+                showExportModal: false
+            });
         });
     }
 


### PR DESCRIPTION
# Persona changes
## Wanted changes from Customer

Remove Family, Familystatus & income in step 1:

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/f9ac1f20-e96b-4e82-962d-2af6016a087a)

Move Statements & Motives under the individual fields. Min and Max values have now also been adjusted. Fields are now named "Kategorien" and the kategory "Wie lässt sich die Persona in ein/zwei Sätzen beschreiben?" has been added in step 2:

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/87139f91-e17a-4ddc-b9cb-7551f670f1bf)

New order in step 3:

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/32a1699d-5b21-40e7-b2a7-1fa89adf105b)

## New PDF Export look (new)
The order in the PDF export has now been changed. The old Version is still visible in the next chapter.

The PDF now looks like this (order changed):

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/b26b9ad7-25e8-4a15-82c5-8b727ab7c996)

File: [Nichlas - 24.10.2023, 17 09 10.pdf](https://github.com/ricom/toolbox-frontend/files/13120012/Nichlas.-.24.10.2023.17.09.10.pdf)



## Persona PDF-Export (old)
You can now export an analysis as an PDF-file. To create the pdf-files an library called [jsPDF](https://github.com/parallax/jsPDF) is used. Although coding the pdf-export is time consuming, the library allows all kinds of graphical manipulation and so on.

Its also now possible to "validate" an export. Meaning if you were to export an PDF, although you don't have sufficient information yet, you can allow the export only to be made while at a specific step.

For example, if you now try to export the persona, while your not at least at step 3 (summary), then you will get the following error message:

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/5b0a64d8-cad9-45d3-83da-7ffaff61df11)

But if you were to export a valid Persona. For example:

![grafik](https://github.com/ricom/toolbox-frontend/assets/43421445/924693ee-d0eb-4e4c-8ce3-c46d49c1856a)

You would get the following PDF-file:  [Testexport - 22.10.2023.pdf 🔗](https://github.com/ricom/toolbox-frontend/files/13062152/Testexport.-.22.10.2023.pdf)

## Development
If your currently building an PDF-Export its better to use the Component `PDFExporterPreview` for preview. Else you would have to export and open the file every time you change something. You can embed this component in a step where the information is sufficient as following:

```javascript
<PDFExporterPreview<PersonaAnalysisValues>
    save={this.props.save}
    exporter={new PersonaPDFExporter()}
    resources={this.props.resourceManager.resources}
/>
```

This will cause the following `iframe` to be created:

![Animation (0)](https://github.com/ricom/toolbox-frontend/assets/43421445/4774d5b8-af6d-47a9-98f1-63b11d045ba7)


